### PR TITLE
Migrate I2S output to 24-bit audio (24-in-32, left-justified)

### DIFF
--- a/AGENTS/audio-runtime.md
+++ b/AGENTS/audio-runtime.md
@@ -42,8 +42,21 @@ parameters.
 
 ## Output format
 
-- Output is **interleaved stereo int16** (`sample_stride = 4`: 2 channels × 2 bytes).
-- Write `out[2*i]` = left, `out[2*i+1]` = right.
+- Default output is **24-bit audio as 24-in-32 left-justified** stereo
+  (`AUDIO_BUFFER_FORMAT_PCM_S32`, `sample_stride = 8`: 2 channels × 4 bytes).
+  The 24 audio bits live in bits 31..8 of each `int32` word; bits 7..0 are zero
+  (the PCM510x clocks them out but ignores them).
+- The producer buffer is `int32_t *out`; write `out[2*i]` = left,
+  `out[2*i+1]` = right. Convert float samples with **`rpdsp::toInt24x32(x)`**
+  (in `rpdsp/algorithm.h`) — it clamps to [-1, 1], scales by 2²³−1, and packs.
+- On the wire this is plain 32-bit I2S (64 BCLK per stereo frame, BCLK ≈ 3.07 MHz
+  at 48 kHz). The driver selects a dedicated 32-bit PIO program
+  (`audio_i2s_32` / `audio_i2s_32_swapped`) for this format.
+- **int16 is still supported** via `AUDIO_BUFFER_FORMAT_PCM_S16`
+  (`sample_stride = 4`, `int16_t *out`, the original `audio_i2s` PIO program).
+  The driver picks the program and DMA transfer count from the buffer's format,
+  so a sketch only changes its `audio_format_t.format`, `sample_stride`, and
+  packing helper to switch.
 
 ## I2S wiring convention
 

--- a/AGENTS/gotchas.md
+++ b/AGENTS/gotchas.md
@@ -8,6 +8,17 @@ Things that don't belong to a single area but trip up edits across the repo.
   declares `SAMPLE_RATE = 48000.0f` (matching `rpdsp::kDefaultSampleRate`). Don't
   introduce a different rate without checking buffer/timing implications.
 
+## Bit depth
+
+- **Project default is 24-in-32 left-justified** via
+  `AUDIO_BUFFER_FORMAT_PCM_S32` (`sample_stride = 8`, `int32_t *out`, pack with
+  `rpdsp::toInt24x32`). All examples use this. See
+  [audio-runtime.md](audio-runtime.md) "Output format" for the full contract.
+- **int16 (`AUDIO_BUFFER_FORMAT_PCM_S16`, `sample_stride = 4`) remains
+  supported** in the driver but is no longer exercised by any example, so it is
+  compile-tested only through the asserts in `audio_i2s.c`. If you touch the
+  driver, keep both the S16 and S32 paths intact.
+
 ## Dual-core split is consistent
 
 - Core 0 (`setup`/`loop`) runs the real-time audio fill callback.

--- a/Docs/rp2350_tuning.md
+++ b/Docs/rp2350_tuning.md
@@ -6,6 +6,8 @@ This guide captures tuning assumptions for the approved target: RP2350, 48 kHz s
 
 - Sample rate: `48000.0f`.
 - DSP format: `float`.
+- Output format: 24-in-32 left-justified `int32` on the I2S wire
+  (`AUDIO_BUFFER_FORMAT_PCM_S32`); int16 still supported.
 - Channels: stereo.
 - Codec path: platform-managed Arduino-Pico I2S.
 - License: MIT.
@@ -87,8 +89,10 @@ The DSP library does not own codec register details, and it does not maintain a 
 - Convert hardware buffers into the `audio_buffer_t*` from `pico_audio_i2s` and
   fill it sample-by-sample in the sketch's `fill_audio_buffer`.
 - Call the DSP graph.
-- Convert processed floats back to the codec sample format (clamp to ±1, scale
-  to int16, write interleaved stereo).
+- Convert processed floats back to the codec sample format. The project default
+  is 24-in-32 left-justified `int32` via `rpdsp::toInt24x32` (clamp to ±1, scale
+  to 2²³−1, pack into bits 31..8), written interleaved stereo with
+  `sample_stride = 8`. int16 packing remains available for the S16 format.
 
 The Arduino-Pico I2S driver (`pico_audio_i2s`) reflects the hardware
 constraints directly: BCLK and LRCLK are an adjacent pin pair

--- a/Examples/LadderFilter/LadderFilter.ino
+++ b/Examples/LadderFilter/LadderFilter.ino
@@ -49,8 +49,6 @@ static const int   BUTTON_PIN  = 0;   // momentary switch, INPUT_PULLUP, active-
 static const int   DEBOUNCE_MS = 20;
 
 static const float SAMPLE_RATE        = 48000.0f;  // == rpdsp::kDefaultSampleRate
-static const float INT16_MAX_F        = 32767.0f;
-static const float INT16_MIN_F        = -32768.0f;
 static const int   NUM_AUDIO_BUFFERS  = 3;
 static const int   SAMPLES_PER_BUFFER = 256;
 
@@ -111,12 +109,6 @@ static inline float centsToRatio(float cents) {
     return powf(2.0f, cents / 1200.0f);
 }
 
-static inline int16_t float_to_int16(float s) {
-    float scaled = s * INT16_MAX_F;
-    scaled = rpdsp::clamp(scaled, INT16_MIN_F, INT16_MAX_F);
-    return static_cast<int16_t>(scaled);
-}
-
 // Point all three detuned oscillators at a MIDI note (called on noteOn edges).
 static void setNote(int midiNote) {
     const float base = rpdsp::midiNoteToHz(static_cast<float>(midiNote));
@@ -132,7 +124,7 @@ static void setNote(int midiNote) {
 static void fill_audio_buffer(audio_buffer_t *buffer)
 {
     const int    N   = static_cast<int>(buffer->max_sample_count);
-    int16_t     *dst = reinterpret_cast<int16_t *>(buffer->buffer->bytes);
+    int32_t     *dst = reinterpret_cast<int32_t *>(buffer->buffer->bytes);
 
     // Consume cross-core note edges once per block. Steps are ~158 ms and blocks
     // are ~5 ms, so per-block consumption sits well inside the gate timing.
@@ -174,7 +166,7 @@ static void fill_audio_buffer(audio_buffer_t *buffer)
         // 4) Makeup + soft-clip so resonant peaks never clip the DAC.
         const float outf = rpdsp::softClip(filt * amp * OUT_MAKEUP) * OUT_HEADROOM;
 
-        const int16_t sample = float_to_int16(outf);
+        const int32_t sample = rpdsp::toInt24x32(outf);
         dst[2 * i + 0] = sample;   // left
         dst[2 * i + 1] = sample;   // right (mono -> stereo)
     }
@@ -219,12 +211,12 @@ void setup()
 
     static audio_format_t audioFmt = {
         .sample_freq   = static_cast<uint32_t>(SAMPLE_RATE),
-        .format        = AUDIO_BUFFER_FORMAT_PCM_S16,
+        .format        = AUDIO_BUFFER_FORMAT_PCM_S32,
         .channel_count = 2
     };
     static audio_buffer_format_t bufFmt = {
         .format        = &audioFmt,
-        .sample_stride = 4            // 2 channels x 2 bytes/sample
+        .sample_stride = 8            // 2 channels x 4 bytes/sample (24-in-32)
     };
 
     producer_pool = audio_new_producer_pool(&bufFmt, NUM_AUDIO_BUFFERS, SAMPLES_PER_BUFFER);

--- a/Examples/Oscillator_HardSync/Oscillator_HardSync.ino
+++ b/Examples/Oscillator_HardSync/Oscillator_HardSync.ino
@@ -26,8 +26,6 @@ static const int PICO_AUDIO_I2S_CLOCK_PIN_BASE = 16; // LRCK = 16, BCLK = 17
 // Audio engine constants
 // ---------------------------------------------------------------------------
 static const float    SAMPLE_RATE        = 48000.0f;
-static const float    INT16_MAX_F        = 32767.0f;
-static const float    INT16_MIN_F        = -32768.0f;
 static const int      NUM_AUDIO_BUFFERS  = 3;
 static const int      SAMPLES_PER_BUFFER = 32;
 
@@ -62,16 +60,6 @@ volatile float g_slave_hz = ROOT_FREQ;
 volatile float g_master_hz = ROOT_FREQ * 0.5f;
 
 // ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-static inline int16_t float_to_int16(float s)
-{
-    float scaled = s * INT16_MAX_F;
-    scaled = rpdsp::clamp(scaled, INT16_MIN_F, INT16_MAX_F);
-    return static_cast<int16_t>(scaled);
-}
-
-// ---------------------------------------------------------------------------
 // Initialise DSP objects (called once from Core 0 setup)
 // ---------------------------------------------------------------------------
 static void initDSP()
@@ -92,7 +80,7 @@ static void initDSP()
 static void fill_audio_buffer(audio_buffer_t *buffer)
 {
     const int    N   = static_cast<int>(buffer->max_sample_count);
-    int16_t     *out = reinterpret_cast<int16_t *>(buffer->buffer->bytes);
+    int32_t     *out = reinterpret_cast<int32_t *>(buffer->buffer->bytes);
 
     for (int i = 0; i < N; ++i)
     {
@@ -106,7 +94,7 @@ static void fill_audio_buffer(audio_buffer_t *buffer)
 
         float signal = rpdsp::softClip(hard_sync_osc.process() * 0.15f);
 
-        int16_t s = float_to_int16(signal * 0.12f);
+        int32_t s = rpdsp::toInt24x32(signal * 0.12f);
         out[2 * i + 0] = s; // Left
         out[2 * i + 1] = s; // Right
     }
@@ -144,12 +132,12 @@ void setup()
 
     static audio_format_t audioFmt = {
         .sample_freq   = static_cast<uint32_t>(SAMPLE_RATE),
-        .format        = AUDIO_BUFFER_FORMAT_PCM_S16,
+        .format        = AUDIO_BUFFER_FORMAT_PCM_S32,
         .channel_count = 2
     };
     static audio_buffer_format_t bufFmt = {
         .format        = &audioFmt,
-        .sample_stride = 4           // 2 channels x 2 bytes/sample
+        .sample_stride = 8           // 2 channels x 4 bytes/sample (24-in-32)
     };
 
     producer_pool = audio_new_producer_pool(&bufFmt, NUM_AUDIO_BUFFERS, SAMPLES_PER_BUFFER);

--- a/Examples/Oscillators/Oscillators.ino
+++ b/Examples/Oscillators/Oscillators.ino
@@ -13,8 +13,6 @@ int PICO_AUDIO_I2S_CLOCK_PIN_BASE = 16; //  Pico forces you to use BasePin + 1 f
 
 
 float SAMPLE_RATE = 48000.0f;
-float INT16_MAX_AS_FLOAT = 32767.0f;
-float INT16_MIN_AS_FLOAT = -32768.0f;
 int NUM_AUDIO_BUFFERS = 3;
 int SAMPLES_PER_BUFFER = 32;
 audio_buffer_pool_t *producer_pool = nullptr;
@@ -36,21 +34,11 @@ osc2.setFreq(720.f);
 
     }
 
-// --- Audio Buffer Conversion ---
-static inline int16_t convertSampleToInt16(float sample)
-{
-    float scaled = sample * INT16_MAX_AS_FLOAT;
-    scaled = roundf(scaled);
-    scaled = rpdsp::clamp(scaled, INT16_MIN_AS_FLOAT, INT16_MAX_AS_FLOAT);
-    return static_cast<int16_t>(scaled);
-}
-
-
 /// AUDIO LOOP
 void fill_audio_buffer(audio_buffer_t *buffer)
 {
     int N = buffer->max_sample_count;
-    int16_t *out = reinterpret_cast<int16_t *>(buffer->buffer->bytes);
+    int32_t *out = reinterpret_cast<int32_t *>(buffer->buffer->bytes);
 
     for (int i = 0; i < N; ++i)
     {
@@ -62,8 +50,8 @@ void fill_audio_buffer(audio_buffer_t *buffer)
 
         // Set the left and right output channels to the final mixed signal
 
-        out[2 * i + 0] = convertSampleToInt16(osc1.process());
-        out[2 * i + 1] = convertSampleToInt16(osc2.process());
+        out[2 * i + 0] = rpdsp::toInt24x32(osc1.process());
+        out[2 * i + 1] = rpdsp::toInt24x32(osc2.process());
     }
 
     buffer->sample_count = N;
@@ -100,11 +88,11 @@ void setup()
     initOscillators();
     static audio_format_t audioFormat = {
         .sample_freq = (uint32_t)SAMPLE_RATE,
-        .format = AUDIO_BUFFER_FORMAT_PCM_S16,
+        .format = AUDIO_BUFFER_FORMAT_PCM_S32,
         .channel_count = 2};
     static audio_buffer_format_t bufferFormat = {
         .format = &audioFormat,
-        .sample_stride = 4};
+        .sample_stride = 8};
     producer_pool = audio_new_producer_pool(&bufferFormat, NUM_AUDIO_BUFFERS, SAMPLES_PER_BUFFER);
     audio_i2s_config_t i2sConfig = {
         .data_pin = PICO_AUDIO_I2S_DATA_PIN,

--- a/Examples/SimpleOscillators/SimpleOscillators.ino
+++ b/Examples/SimpleOscillators/SimpleOscillators.ino
@@ -26,8 +26,6 @@ static const int PICO_AUDIO_I2S_CLOCK_PIN_BASE = 16; // LRCK = 16, BCLK = 17
 // Audio engine constants
 // ---------------------------------------------------------------------------
 static const float    SAMPLE_RATE        = 48000.0f;
-static const float    INT16_MAX_F        = 32767.0f;
-static const float    INT16_MIN_F        = -32768.0f;
 static const int      NUM_AUDIO_BUFFERS  = 3;
 static const int      SAMPLES_PER_BUFFER = 32;
 
@@ -62,16 +60,6 @@ volatile float g_slave_hz = ROOT_FREQ;
 volatile float g_master_hz = ROOT_FREQ * 0.5f;
 
 // ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-static inline int16_t float_to_int16(float s)
-{
-    float scaled = s * INT16_MAX_F;
-    scaled = rpdsp::clamp(scaled, INT16_MIN_F, INT16_MAX_F);
-    return static_cast<int16_t>(scaled);
-}
-
-// ---------------------------------------------------------------------------
 // Initialise DSP objects (called once from Core 0 setup)
 // ---------------------------------------------------------------------------
 static void initDSP()
@@ -92,7 +80,7 @@ static void initDSP()
 static void fill_audio_buffer(audio_buffer_t *buffer)
 {
     const int    N   = static_cast<int>(buffer->max_sample_count);
-    int16_t     *out = reinterpret_cast<int16_t *>(buffer->buffer->bytes);
+    int32_t     *out = reinterpret_cast<int32_t *>(buffer->buffer->bytes);
 
     for (int i = 0; i < N; ++i)
     {
@@ -106,7 +94,7 @@ static void fill_audio_buffer(audio_buffer_t *buffer)
 
         float signal = rpdsp::softClip(hard_sync_osc.process() * 0.15f);
 
-        int16_t s = float_to_int16(signal * 0.12f);
+        int32_t s = rpdsp::toInt24x32(signal * 0.12f);
         out[2 * i + 0] = s; // Left
         out[2 * i + 1] = s; // Right
     }
@@ -144,12 +132,12 @@ void setup()
 
     static audio_format_t audioFmt = {
         .sample_freq   = static_cast<uint32_t>(SAMPLE_RATE),
-        .format        = AUDIO_BUFFER_FORMAT_PCM_S16,
+        .format        = AUDIO_BUFFER_FORMAT_PCM_S32,
         .channel_count = 2
     };
     static audio_buffer_format_t bufFmt = {
         .format        = &audioFmt,
-        .sample_stride = 4           // 2 channels x 2 bytes/sample
+        .sample_stride = 8           // 2 channels x 4 bytes/sample (24-in-32)
     };
 
     producer_pool = audio_new_producer_pool(&bufFmt, NUM_AUDIO_BUFFERS, SAMPLES_PER_BUFFER);

--- a/Examples/SuperSaw/SuperSaw.ino
+++ b/Examples/SuperSaw/SuperSaw.ino
@@ -26,8 +26,6 @@ static const int PICO_AUDIO_I2S_CLOCK_PIN_BASE = 16; // LRCK = 16, BCLK = 17
 // Audio engine constants
 // ---------------------------------------------------------------------------
 static const float    SAMPLE_RATE        = 48000.0f;
-static const float    INT16_MAX_F        = 32767.0f;
-static const float    INT16_MIN_F        = -32768.0f;
 static const int      NUM_AUDIO_BUFFERS  = 3;
 static const int      SAMPLES_PER_BUFFER = 256;
 
@@ -61,29 +59,19 @@ static void initHypersaw()
 }
 
 // ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-static inline int16_t float_to_int16(float s)
-{
-    float scaled = s * INT16_MAX_F;
-    scaled = rpdsp::clamp(scaled, INT16_MIN_F, INT16_MAX_F);
-    return static_cast<int16_t>(scaled);
-}
-
-// ---------------------------------------------------------------------------
 // Audio fill callback - Core 0 hot path; must not block
 // ---------------------------------------------------------------------------
 static void fill_audio_buffer(audio_buffer_t *buffer)
 {
     const int    N   = static_cast<int>(buffer->max_sample_count);
-    int16_t     *out = reinterpret_cast<int16_t *>(buffer->buffer->bytes);
+    int32_t     *out = reinterpret_cast<int32_t *>(buffer->buffer->bytes);
 
     for (int i = 0; i < N; ++i)
     {
         float mixed_signal = hypersaw.process();
         mixed_signal *= 0.33f;
 
-        int16_t s = float_to_int16(mixed_signal);
+        int32_t s = rpdsp::toInt24x32(mixed_signal);
         out[2 * i + 0] = s; // Left
         out[2 * i + 1] = s; // Right
     }
@@ -121,12 +109,12 @@ void setup()
 
     static audio_format_t audioFmt = {
         .sample_freq   = static_cast<uint32_t>(SAMPLE_RATE),
-        .format        = AUDIO_BUFFER_FORMAT_PCM_S16,
+        .format        = AUDIO_BUFFER_FORMAT_PCM_S32,
         .channel_count = 2
     };
     static audio_buffer_format_t bufFmt = {
         .format        = &audioFmt,
-        .sample_stride = 4           // 2 channels x 2 bytes/sample
+        .sample_stride = 8           // 2 channels x 4 bytes/sample (24-in-32)
     };
 
     producer_pool = audio_new_producer_pool(&bufFmt, NUM_AUDIO_BUFFERS, SAMPLES_PER_BUFFER);

--- a/Examples/TwoChannelOscillator/TwoChannelOscillator.ino
+++ b/Examples/TwoChannelOscillator/TwoChannelOscillator.ino
@@ -25,8 +25,6 @@ int PICO_AUDIO_I2S_CLOCK_PIN_BASE = 16; // LRCK=16, BCLK=17
 
 // ─── Audio engine constants ───────────────────────────────────────────────────
 const float SAMPLE_RATE      = 48000.0f;
-const float INT16_MAX_F      = 32767.0f;
-const float INT16_MIN_F      = -32768.0f;
 const int   NUM_AUDIO_BUFFERS  = 3;
 const int   SAMPLES_PER_BUFFER = 32;
 
@@ -62,25 +60,18 @@ static inline float mapFine(float adc12) {
     return ((adc12 / 4095.0f) - 0.5f) * (FINE_RANGE_HZ * 2.0f);
 }
 
-// ─── Audio helpers ────────────────────────────────────────────────────────────
-static inline int16_t toInt16(float s) {
-    float v = roundf(s * INT16_MAX_F);
-    v = rpdsp::clamp(v, INT16_MIN_F, INT16_MAX_F);
-    return static_cast<int16_t>(v);
-}
-
 // ─── Audio callback (Core 0) ──────────────────────────────────────────────────
 void fill_audio_buffer(audio_buffer_t *buffer) {
     int      N   = buffer->max_sample_count;
-    int16_t *out = reinterpret_cast<int16_t *>(buffer->buffer->bytes);
+    int32_t *out = reinterpret_cast<int32_t *>(buffer->buffer->bytes);
 
     // Snapshot frequencies once per buffer to avoid tearing mid-fill.
     osc_left.setFreq(left_freq);
     osc_right.setFreq(right_freq);
 
     for (int i = 0; i < N; ++i) {
-        out[2 * i + 0] = toInt16(osc_left.process() * 0.8f);   // left
-        out[2 * i + 1] = toInt16(osc_right.process() * 0.8f);  // right
+        out[2 * i + 0] = rpdsp::toInt24x32(osc_left.process() * 0.8f);   // left
+        out[2 * i + 1] = rpdsp::toInt24x32(osc_right.process() * 0.8f);  // right
     }
     buffer->sample_count = N;
 }
@@ -114,12 +105,12 @@ void setup() {
 
     static audio_format_t fmt = {
         .sample_freq  = (uint32_t)SAMPLE_RATE,
-        .format       = AUDIO_BUFFER_FORMAT_PCM_S16,
+        .format       = AUDIO_BUFFER_FORMAT_PCM_S32,
         .channel_count = 2
     };
     static audio_buffer_format_t bfmt = {
         .format        = &fmt,
-        .sample_stride = 4
+        .sample_stride = 8
     };
     producer_pool = audio_new_producer_pool(&bfmt, NUM_AUDIO_BUFFERS, SAMPLES_PER_BUFFER);
 

--- a/libraries/pico_audio_i2s/extras/audio_i2s.pio
+++ b/libraries/pico_audio_i2s/extras/audio_i2s.pio
@@ -54,12 +54,51 @@ bitloop1:           ;        ||
     out pins, 1       side 0b00
     set x, 14         side 0b10
                                
-bitloop0:                      
+bitloop0:
     out pins, 1       side 0b00
     jmp x-- bitloop0  side 0b10
     out pins, 1       side 0b01
-public entry_point:            
+public entry_point:
     set x, 14         side 0b11
+
+; 24-in-32 left-justified variant: 32 bits per half-frame instead of 16.
+; Identical structure to audio_i2s; only the "set x" count changes (14 -> 30),
+; so each channel slot clocks out 32 BCLK ticks (64 per stereo frame).
+.program audio_i2s_32
+.side_set 2
+
+                    ;        /--- LRCLK
+                    ;        |/-- BCLK
+bitloop1:           ;        ||
+    out pins, 1       side 0b10
+    jmp x-- bitloop1  side 0b11
+    out pins, 1       side 0b00
+    set x, 30         side 0b01
+
+bitloop0:
+    out pins, 1       side 0b00
+    jmp x-- bitloop0  side 0b01
+    out pins, 1       side 0b10
+public entry_point:
+    set x, 30         side 0b11
+
+.program audio_i2s_32_swapped
+.side_set 2
+
+                    ;        /--- BCLK
+                    ;        |/-- LRCLK
+bitloop1:           ;        ||
+    out pins, 1       side 0b01
+    jmp x-- bitloop1  side 0b11
+    out pins, 1       side 0b00
+    set x, 30         side 0b10
+
+bitloop0:
+    out pins, 1       side 0b00
+    jmp x-- bitloop0  side 0b10
+    out pins, 1       side 0b01
+public entry_point:
+    set x, 30         side 0b11
 
 % c-sdk {
 
@@ -83,6 +122,28 @@ static inline void audio_i2s_program_init(PIO pio, uint sm, uint offset, uint da
     pio_sm_set_pins(pio, sm, 0); // clear pins
 
     pio_sm_exec(pio, sm, pio_encode_jmp(offset + audio_i2s_offset_entry_point));
+}
+
+static inline void audio_i2s_32_program_init(PIO pio, uint sm, uint offset, uint data_pin, uint clock_pin_base) {
+    pio_sm_config sm_config = audio_i2s_32_program_get_default_config(offset);
+
+    sm_config_set_out_pins(&sm_config, data_pin, 1);
+    sm_config_set_sideset_pins(&sm_config, clock_pin_base);
+    sm_config_set_out_shift(&sm_config, false, true, 32);
+    sm_config_set_fifo_join(&sm_config, PIO_FIFO_JOIN_TX);
+
+    pio_sm_init(pio, sm, offset, &sm_config);
+
+#if PICO_PIO_USE_GPIO_BASE
+    uint64_t pin_mask = (1ull << data_pin) | (3ull << clock_pin_base);
+    pio_sm_set_pindirs_with_mask64(pio, sm, pin_mask, pin_mask);
+#else
+    uint32_t pin_mask = (1u << data_pin) | (3u << clock_pin_base);
+    pio_sm_set_pindirs_with_mask(pio, sm, pin_mask, pin_mask);
+#endif
+    pio_sm_set_pins(pio, sm, 0); // clear pins
+
+    pio_sm_exec(pio, sm, pio_encode_jmp(offset + audio_i2s_32_offset_entry_point));
 }
 
 %}

--- a/libraries/pico_audio_i2s/src/pico_audio_i2s/audio.cpp
+++ b/libraries/pico_audio_i2s/src/pico_audio_i2s/audio.cpp
@@ -254,4 +254,13 @@ void stereo_to_stereo_producer_give(audio_connection_t *connection, audio_buffer
     return producer_pool_blocking_give<Stereo<FmtS16>, Stereo<FmtS16>>(connection, buffer);
 }
 
+// S32 (24-in-32) pass-through: identity copy of int32 stereo frames.
+audio_buffer_t *stereo_to_stereo_consumer_take_s32(audio_connection_t *connection, bool block) {
+    return consumer_pool_take<Stereo<FmtS32>, Stereo<FmtS32>>(connection, block);
+}
+
+void stereo_to_stereo_producer_give_s32(audio_connection_t *connection, audio_buffer_t *buffer) {
+    return producer_pool_blocking_give<Stereo<FmtS32>, Stereo<FmtS32>>(connection, buffer);
+}
+
 #endif

--- a/libraries/pico_audio_i2s/src/pico_audio_i2s/audio.h
+++ b/libraries/pico_audio_i2s/src/pico_audio_i2s/audio.h
@@ -43,6 +43,7 @@ extern "C" {
 #define AUDIO_BUFFER_FORMAT_PCM_S8 2           ///< signed 8bit PCM
 #define AUDIO_BUFFER_FORMAT_PCM_U16 3          ///< unsigned 16bit PCM
 #define AUDIO_BUFFER_FORMAT_PCM_U8 4           ///< unsigned 8bit PCM
+#define AUDIO_BUFFER_FORMAT_PCM_S32 5          ///< signed 32bit container, 24-in-32 audio left-justified (bits 31..8 audio, 7..0 zero)
 
 /** \brief Audio format definition
  */
@@ -294,6 +295,16 @@ audio_buffer_t *mono_s8_to_stereo_consumer_take(audio_connection_t *connection, 
  *  \ingroup pico_audio
  */
 void stereo_to_stereo_producer_give(audio_connection_t *connection, audio_buffer_t *buffer);
+
+/*! \brief Stereo S32 (24-in-32) consumer take; identity copy of int32 frames.
+ *  \ingroup pico_audio
+ */
+audio_buffer_t *stereo_to_stereo_consumer_take_s32(audio_connection_t *connection, bool block);
+
+/*! \brief Stereo S32 (24-in-32) producer give; identity copy of int32 frames.
+ *  \ingroup pico_audio
+ */
+void stereo_to_stereo_producer_give_s32(audio_connection_t *connection, audio_buffer_t *buffer);
 
 // not worth a separate header for now
 typedef struct __packed pio_audio_channel_config {

--- a/libraries/pico_audio_i2s/src/pico_audio_i2s/audio_i2s.c
+++ b/libraries/pico_audio_i2s/src/pico_audio_i2s/audio_i2s.c
@@ -63,16 +63,24 @@ const audio_format_t *audio_i2s_setup(const audio_format_t *intended_audio_forma
     pio_sm_claim(audio_pio, sm);
 
 
-    const struct pio_program *program =
+    // 24-in-32 left-justified output uses a sibling PIO program that clocks 32
+    // bits per channel slot instead of 16; everything else (autopull threshold,
+    // DMA width) is shared with the S16 program.
+    bool is_s32 = (intended_audio_format->format == AUDIO_BUFFER_FORMAT_PCM_S32);
+
+    const struct pio_program *program;
 #if PICO_AUDIO_I2S_CLOCK_PINS_SWAPPED
-        &audio_i2s_swapped_program
+    program = is_s32 ? &audio_i2s_32_swapped_program : &audio_i2s_swapped_program;
 #else
-        &audio_i2s_program
+    program = is_s32 ? &audio_i2s_32_program : &audio_i2s_program;
 #endif
-        ;
     uint offset = pio_add_program(audio_pio, program);
 
-    audio_i2s_program_init(audio_pio, sm, offset, config->data_pin, config->clock_pin_base);
+    if (is_s32) {
+        audio_i2s_32_program_init(audio_pio, sm, offset, config->data_pin, config->clock_pin_base);
+    } else {
+        audio_i2s_program_init(audio_pio, sm, offset, config->data_pin, config->clock_pin_base);
+    }
 
     __mem_fence_release();
     uint8_t dma_channel = config->dma_channel;
@@ -125,6 +133,8 @@ static audio_buffer_t *wrap_consumer_take(audio_connection_t *connection, bool b
 #if PICO_AUDIO_I2S_MONO_OUTPUT
     unsupported;
 #else
+    if (connection->producer_pool->format->format == AUDIO_BUFFER_FORMAT_PCM_S32)
+        return stereo_to_stereo_consumer_take_s32(connection, block);
     return stereo_to_stereo_consumer_take(connection, block);
 #endif
 #endif
@@ -147,6 +157,8 @@ static void wrap_producer_give(audio_connection_t *connection, audio_buffer_t *b
 #if PICO_AUDIO_I2S_MONO_OUTPUT
     unsupported;
 #else
+    if (connection->producer_pool->format->format == AUDIO_BUFFER_FORMAT_PCM_S32)
+        return stereo_to_stereo_producer_give_s32(connection, buffer);
     return stereo_to_stereo_producer_give(connection, buffer);
 #endif
 #endif
@@ -200,17 +212,22 @@ bool audio_i2s_connect_extra(audio_buffer_pool_t *producer, bool buffer_on_give,
     printf("Connecting PIO I2S audio\n");
 
     // todo we need to pick a connection based on the frequency - e.g. 22050 can be more simply upsampled to 44100
-    assert(producer->format->format == AUDIO_BUFFER_FORMAT_PCM_S16);
-    pio_i2s_consumer_format.format = AUDIO_BUFFER_FORMAT_PCM_S16;
+    assert(producer->format->format == AUDIO_BUFFER_FORMAT_PCM_S16
+        || producer->format->format == AUDIO_BUFFER_FORMAT_PCM_S32);
+    pio_i2s_consumer_format.format = producer->format->format;
     // todo we could do mono
     // todo we can't match exact, so we should return what we can do
     pio_i2s_consumer_format.sample_freq = producer->format->sample_freq;
 #if PICO_AUDIO_I2S_MONO_OUTPUT
+    if (producer->format->format == AUDIO_BUFFER_FORMAT_PCM_S32) {
+        panic("S32 mono output not supported yet");
+    }
     pio_i2s_consumer_format.channel_count = 1;
     pio_i2s_consumer_buffer_format.sample_stride = 2;
 #else
     pio_i2s_consumer_format.channel_count = 2;
-    pio_i2s_consumer_buffer_format.sample_stride = 4;
+    pio_i2s_consumer_buffer_format.sample_stride =
+        (producer->format->format == AUDIO_BUFFER_FORMAT_PCM_S32) ? 8 : 4;
 #endif
 
     audio_i2s_consumer = audio_new_consumer_pool(&pio_i2s_consumer_buffer_format, buffer_count, samples_per_buffer);
@@ -331,18 +348,26 @@ static inline void audio_start_dma_transfer() {
     }
     assert(ab->sample_count);
     // todo better naming of format->format->format!!
-    assert(ab->format->format->format == AUDIO_BUFFER_FORMAT_PCM_S16);
+    assert(ab->format->format->format == AUDIO_BUFFER_FORMAT_PCM_S16
+        || ab->format->format->format == AUDIO_BUFFER_FORMAT_PCM_S32);
 #if PICO_AUDIO_I2S_MONO_OUTPUT
+    assert(ab->format->format->format == AUDIO_BUFFER_FORMAT_PCM_S16);
     assert(ab->format->format->channel_count == 1);
     assert(ab->format->sample_stride == 2);
+    uint32_t words_per_frame = 1u;
 #else
     assert(ab->format->format->channel_count == 2);
-    assert(ab->format->sample_stride == 4);
+    assert(ab->format->sample_stride == 4 || ab->format->sample_stride == 8);
+    // S16 packs L|R into a single 32-bit DMA word per frame; S32 sends L and R as
+    // two separate 32-bit words, so the transfer count doubles. The DMA transfer
+    // *width* stays DMA_SIZE_32 in both cases (configured in audio_i2s_setup).
+    uint32_t words_per_frame =
+        (ab->format->format->format == AUDIO_BUFFER_FORMAT_PCM_S32) ? 2u : 1u;
 #endif
     dma_channel_config c = dma_get_channel_config(shared_state.dma_channel);
     channel_config_set_read_increment(&c, true);
     dma_channel_set_config(shared_state.dma_channel, &c, false);
-    dma_channel_transfer_from_buffer_now(shared_state.dma_channel, ab->buffer->bytes, ab->sample_count);
+    dma_channel_transfer_from_buffer_now(shared_state.dma_channel, ab->buffer->bytes, ab->sample_count * words_per_frame);
 }
 
 // irq handler for DMA

--- a/libraries/pico_audio_i2s/src/pico_audio_i2s/audio_i2s.pio.h
+++ b/libraries/pico_audio_i2s/src/pico_audio_i2s/audio_i2s.pio.h
@@ -101,4 +101,97 @@ static inline void audio_i2s_program_init(PIO pio, uint sm, uint offset, uint da
 }
 
 #endif
+
+// ------------ //
+// audio_i2s_32 //
+// ------------ //
+
+#define audio_i2s_32_wrap_target 0
+#define audio_i2s_32_wrap 7
+
+#define audio_i2s_32_offset_entry_point 7u
+
+static const uint16_t audio_i2s_32_program_instructions[] = {
+            //     .wrap_target
+    0x7001, //  0: out    pins, 1         side 2
+    0x1840, //  1: jmp    x--, 0          side 3
+    0x6001, //  2: out    pins, 1         side 0
+    0xe83e, //  3: set    x, 30           side 1
+    0x6001, //  4: out    pins, 1         side 0
+    0x0844, //  5: jmp    x--, 4          side 1
+    0x7001, //  6: out    pins, 1         side 2
+    0xf83e, //  7: set    x, 30           side 3
+            //     .wrap
+};
+
+#if !PICO_NO_HARDWARE
+static const struct pio_program audio_i2s_32_program = {
+    .instructions = audio_i2s_32_program_instructions,
+    .length = 8,
+    .origin = -1,
+};
+
+static inline pio_sm_config audio_i2s_32_program_get_default_config(uint offset) {
+    pio_sm_config c = pio_get_default_sm_config();
+    sm_config_set_wrap(&c, offset + audio_i2s_32_wrap_target, offset + audio_i2s_32_wrap);
+    sm_config_set_sideset(&c, 2, false, false);
+    return c;
+}
+#endif
+
+// -------------------- //
+// audio_i2s_32_swapped //
+// -------------------- //
+
+#define audio_i2s_32_swapped_wrap_target 0
+#define audio_i2s_32_swapped_wrap 7
+
+#define audio_i2s_32_swapped_offset_entry_point 7u
+
+static const uint16_t audio_i2s_32_swapped_program_instructions[] = {
+            //     .wrap_target
+    0x6801, //  0: out    pins, 1         side 1
+    0x1840, //  1: jmp    x--, 0          side 3
+    0x6001, //  2: out    pins, 1         side 0
+    0xf03e, //  3: set    x, 30           side 2
+    0x6001, //  4: out    pins, 1         side 0
+    0x1044, //  5: jmp    x--, 4          side 2
+    0x6801, //  6: out    pins, 1         side 1
+    0xf83e, //  7: set    x, 30           side 3
+            //     .wrap
+};
+
+#if !PICO_NO_HARDWARE
+static const struct pio_program audio_i2s_32_swapped_program = {
+    .instructions = audio_i2s_32_swapped_program_instructions,
+    .length = 8,
+    .origin = -1,
+};
+
+static inline pio_sm_config audio_i2s_32_swapped_program_get_default_config(uint offset) {
+    pio_sm_config c = pio_get_default_sm_config();
+    sm_config_set_wrap(&c, offset + audio_i2s_32_swapped_wrap_target, offset + audio_i2s_32_swapped_wrap);
+    sm_config_set_sideset(&c, 2, false, false);
+    return c;
+}
+
+static inline void audio_i2s_32_program_init(PIO pio, uint sm, uint offset, uint data_pin, uint clock_pin_base) {
+    pio_sm_config sm_config = audio_i2s_32_program_get_default_config(offset);
+    sm_config_set_out_pins(&sm_config, data_pin, 1);
+    sm_config_set_sideset_pins(&sm_config, clock_pin_base);
+    sm_config_set_out_shift(&sm_config, false, true, 32);
+    sm_config_set_fifo_join(&sm_config, PIO_FIFO_JOIN_TX);
+    pio_sm_init(pio, sm, offset, &sm_config);
+#if PICO_PIO_USE_GPIO_BASE
+    uint64_t pin_mask = (1ull << data_pin) | (3ull << clock_pin_base);
+    pio_sm_set_pindirs_with_mask64(pio, sm, pin_mask, pin_mask);
+#else
+    uint32_t pin_mask = (1u << data_pin) | (3u << clock_pin_base);
+    pio_sm_set_pindirs_with_mask(pio, sm, pin_mask, pin_mask);
+#endif
+    pio_sm_set_pins(pio, sm, 0); // clear pins
+    pio_sm_exec(pio, sm, pio_encode_jmp(offset + audio_i2s_32_offset_entry_point));
+}
+
+#endif
 #endif

--- a/libraries/pico_audio_i2s/src/pico_audio_i2s/sample_conversion.h
+++ b/libraries/pico_audio_i2s/src/pico_audio_i2s/sample_conversion.h
@@ -33,6 +33,12 @@ struct FmtU16 : public FmtDetails<uint16_t> {
 struct FmtS16 : public FmtDetails<int16_t> {
 };
 
+// 24-in-32 left-justified audio rides in a plain int32 container; the pass-through
+// only ever copies S32->S32, so the generic memcpy specialization handles it and
+// no sample_converter arithmetic is required.
+struct FmtS32 : public FmtDetails<int32_t> {
+};
+
 // Multi-channel is just N samples back to back
 template<typename Fmt, uint ChannelCount>
 struct MultiChannelFmt {

--- a/libraries/rpdsp/src/rpdsp/algorithm.h
+++ b/libraries/rpdsp/src/rpdsp/algorithm.h
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <limits>
 
 namespace rpdsp {
@@ -18,6 +19,20 @@ inline float clamp(float value, float low, float high) {
 // Normalized modulation, mix, and envelope values live on [0, 1].
 inline float clamp01(float value) {
   return clamp(value, 0.0f, 1.0f);
+}
+
+// Convert a [-1, 1] float to a 24-in-32 left-justified int32 word for I2S output.
+// Bits 31..8 hold the 24 audio bits; bits 7..0 are zero (the DAC clocks them out
+// but ignores them). Branch-free and allocation-free; safe for the realtime
+// audio callback. Scale is 2^23 - 1 so +1.0 maps to positive full-scale
+// (0x7FFFFF00) without overflowing the 24-bit range. Truncates toward zero; the
+// ~0.5 LSB error is inaudible at 24-bit and avoids a libc roundf() call.
+inline int32_t toInt24x32(float sample) {
+  const float clamped = clamp(sample, -1.0f, 1.0f);
+  const int32_t s = static_cast<int32_t>(clamped * 8388607.0f);  // 2^23 - 1
+  // Shift in the unsigned domain: left-shifting a negative signed value is UB
+  // before C++20, and the bit pattern is identical either way.
+  return static_cast<int32_t>(static_cast<uint32_t>(s) << 8);
 }
 
 // Linear interpolation; pass a clamped t when overshoot is not desired.

--- a/tests/test_algorithm.cpp
+++ b/tests/test_algorithm.cpp
@@ -15,6 +15,38 @@ TEST_CASE("clamp01 maps to [0,1]") {
     CHECK(rpdsp::clamp01(0.3f) == doctest::Approx(0.3f));
 }
 
+TEST_CASE("toInt24x32 packs 24-in-32 left-justified") {
+    // Scale is 2^23 - 1 (8388607) with truncation toward zero, then << 8.
+    CHECK(rpdsp::toInt24x32(0.0f) == 0);
+
+    // +1.0 -> +8388607 (0x7FFFFF) << 8 = 0x7FFFFF00 (positive full-scale).
+    CHECK(rpdsp::toInt24x32(1.0f) == static_cast<int32_t>(0x7FFFFF00));
+
+    // -1.0 -> -8388607 (0xFF800001) << 8 = 0x80000100. Note: with symmetric
+    // scaling this is one 24-bit LSB shy of true negative full-scale (0x80000000),
+    // which is the standard, inaudible consequence of scaling by 2^23 - 1.
+    CHECK(rpdsp::toInt24x32(-1.0f) == static_cast<int32_t>(0x80000100));
+
+    // 0.5 -> 4194303 (0x3FFFFF, truncated from 4194303.5) << 8 = 0x3FFFFF00.
+    CHECK(rpdsp::toInt24x32(0.5f) == static_cast<int32_t>(0x3FFFFF00));
+
+    // Low 8 bits are always zero (DAC padding).
+    CHECK((rpdsp::toInt24x32(0.123f) & 0xFF) == 0);
+    CHECK((rpdsp::toInt24x32(-0.777f) & 0xFF) == 0);
+}
+
+TEST_CASE("toInt24x32 is monotonic across the range") {
+    CHECK(rpdsp::toInt24x32(-0.5f) < rpdsp::toInt24x32(0.0f));
+    CHECK(rpdsp::toInt24x32(0.0f) < rpdsp::toInt24x32(0.5f));
+    CHECK(rpdsp::toInt24x32(0.25f) < rpdsp::toInt24x32(0.75f));
+}
+
+TEST_CASE("toInt24x32 clamps out-of-range input") {
+    CHECK(rpdsp::toInt24x32(2.0f) == rpdsp::toInt24x32(1.0f));
+    CHECK(rpdsp::toInt24x32(-2.0f) == rpdsp::toInt24x32(-1.0f));
+    CHECK(rpdsp::toInt24x32(100.0f) == static_cast<int32_t>(0x7FFFFF00));
+}
+
 TEST_CASE("midiNoteToHz: A4 = 440, A5 = 880") {
     CHECK(rpdsp::midiNoteToHz(69) == doctest::Approx(440.0f).epsilon(0.001f));
     CHECK(rpdsp::midiNoteToHz(81) == doctest::Approx(880.0f).epsilon(0.001f));

--- a/tests/test_oscillator.cpp
+++ b/tests/test_oscillator.cpp
@@ -13,8 +13,8 @@ TEST_CASE("SineOscillator output stays in [-1, 1]") {
     }
 }
 
-TEST_CASE("SawOscillator output stays in [-1, 1]") {
-    rpdsp::SawOscillator osc;
+TEST_CASE("SawOsc output stays in [-1, 1]") {
+    rpdsp::SawOsc osc;
     osc.prepare(48000.0f);
     osc.setFreq(220.0f);
     for (int i = 0; i < 1000; ++i) {


### PR DESCRIPTION
## Summary

Implements the approved 24-bit audio design: adds a signed-32-bit output format (`AUDIO_BUFFER_FORMAT_PCM_S32`) that transmits 24 audio bits left-justified in a 32-bit I2S word (bits 31..8 audio, 7..0 zero), and migrates all six example sketches to it. **int16 output remains fully supported** — the driver picks the PIO program and DMA transfer count from the buffer's format.

## Changes

**Library (`pico_audio_i2s`)**
- `audio.h`: add `AUDIO_BUFFER_FORMAT_PCM_S32` (= 5) and the S32 stereo pass-through declarations.
- `extras/audio_i2s.pio` + `audio_i2s.pio.h`: add `audio_i2s_32` / `audio_i2s_32_swapped` programs (`set x, 30` → 32 BCLK ticks per channel slot) and `audio_i2s_32_program_init`. All four new `set x, 30` encodings (`0xe83e`, `0xf83e`, `0xf03e`, `0xf83e`) were derived against the PIO SET instruction format; every other instruction word is byte-identical to the existing 16-bit programs. **pioasm was not available in this environment** — see the risk note below.
- `audio_i2s.c`: select the PIO program from `intended_audio_format->format`; branch the connect / DMA / consumer-take / producer-give paths on S16 vs S32; double the DMA transfer count for S32 (two 32-bit words per stereo frame). S32 mono output `panic`s (no example uses mono).
- `sample_conversion.h` / `audio.cpp`: add `FmtS32` and the S32 identity pass-through.

**rpdsp**
- `algorithm.h`: add `rpdsp::toInt24x32(float)` — clamps to `[-1, 1]`, scales by `2²³−1`, packs into bits 31..8 using a UB-free unsigned shift.

**Examples** — all six migrated to S32 (`sample_stride = 8`, `int32_t` out buffers, `rpdsp::toInt24x32`), per-sketch int16 packing helpers removed.

**Tests** — added host coverage for `toInt24x32` (exact full-scale values, monotonicity, clamping). Full suite passes (14 cases / 204k assertions).

**Docs** — `AGENTS/audio-runtime.md`, `AGENTS/gotchas.md`, `Docs/rp2350_tuning.md` updated to describe the new default.

## Notes / deviations from the spec

- **Corrected test expectations.** The design doc's expected values for `toInt24x32(-1.0f)` (`0x80000000`) and `toInt24x32(0.5f)` (`0x40000000`) are inconsistent with its own chosen implementation (scale `2²³−1` + truncate). The actual, verified values are `0x80000100` and `0x3FFFFF00`; the committed tests use these. The asymmetry (negative full-scale is one 24-bit LSB shy of `0x80000000`) is the standard, inaudible consequence of symmetric `2²³−1` scaling.
- **`inline` not `static inline`** for `toInt24x32`, to match the style of the neighbouring `rpdsp::clamp`.
- **Incidental fix:** `tests/test_oscillator.cpp` referenced a non-existent `rpdsp::SawOscillator`; the class is `SawOsc`. This pre-existing typo prevented the entire doctest suite (including the new tests) from compiling, so it's fixed here.

## Verification

- ✅ Host doctest suite builds and passes (incl. new `toInt24x32` cases).
- ⚠️ **Firmware not built off-target** — `arduino-cli` is unavailable in this environment, and per `AGENTS/build.md` the PIO/DMA/DAC path can't be verified off-target. Before merge, please run `scripts/build_all_examples.sh` and flash one sketch to confirm tone + noise floor. **Highest-risk item: the hand-derived PIO encodings** — ideally regenerate `audio_i2s.pio.h` with real `pioasm` and confirm the diff matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gv9AsdszgBqpXeeELBL4qh)_